### PR TITLE
Ignore invalid attribute names on jsoup to W3C conversion

### DIFF
--- a/src/main/java/org/aludratest/service/gui/web/selenium/util/DocCache.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/util/DocCache.java
@@ -16,7 +16,6 @@
 package org.aludratest.service.gui.web.selenium.util;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
@@ -30,9 +29,7 @@ import javax.xml.xpath.XPathFactory;
 import org.aludratest.exception.AutomationException;
 import org.aludratest.service.locator.element.XPathLocator;
 import org.aludratest.util.MostRecentUseCache;
-import org.apache.commons.io.FileUtils;
 import org.jsoup.Jsoup;
-import org.jsoup.helper.W3CDom;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -93,11 +90,6 @@ public final class DocCache {
         catch (XPathExpressionException e) {
             throw new AutomationException("Illegal XPath: " + xpath, e);
         }
-    }
-
-    public static void main(String[] args) throws IOException {
-        String html = FileUtils.readFileToString(new File("test.html"));
-        System.out.println(evalXPathInHTMLAsString("/html/head/title/text()", html));
     }
 
     public static String evalXPathInHTMLAsString(String xpath, String html) {

--- a/src/main/java/org/aludratest/service/gui/web/selenium/util/W3CDom.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/util/W3CDom.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2010-2014 Hamburg Sud and the contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aludratest.service.gui.web.selenium.util;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.jsoup.helper.StringUtil;
+import org.jsoup.helper.Validate;
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.select.NodeTraversor;
+import org.jsoup.select.NodeVisitor;
+import org.w3c.dom.Comment;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Text;
+
+// copied from JSoup to be able to ignore invalid attributes.
+// This emulates a more "greedy" translation, as browsers do.
+/** Helper class to transform a {@link org.jsoup.nodes.Document} to a {@link org.w3c.dom.Document org.w3c.dom.Document}, for
+ * integration with toolsets that use the W3C DOM.
+ * <p>
+ * This class is currently <b>experimental</b>, please provide feedback on utility and any problems experienced.
+ * </p>
+*/
+public class W3CDom {
+    protected DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+    /** Convert a jsoup Document to a W3C Document.
+     * @param in jsoup doc
+     * @return w3c doc */
+    public Document fromJsoup(org.jsoup.nodes.Document in) {
+        Validate.notNull(in);
+        DocumentBuilder builder;
+        try {
+            // set the factory to be namespace-aware
+            factory.setNamespaceAware(true);
+            builder = factory.newDocumentBuilder();
+            Document out = builder.newDocument();
+            convert(in, out);
+            return out;
+        }
+        catch (ParserConfigurationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /** Converts a jsoup document into the provided W3C Document. If required, you can set options on the output document before
+     * converting.
+     * @param in jsoup doc
+     * @param out w3c doc
+     * @see org.jsoup.helper.W3CDom#fromJsoup(org.jsoup.nodes.Document) */
+    public void convert(org.jsoup.nodes.Document in, Document out) {
+        if (!StringUtil.isBlank(in.location()))
+            out.setDocumentURI(in.location());
+
+        org.jsoup.nodes.Element rootEl = in.child(0); // skip the #root node
+        NodeTraversor traversor = new NodeTraversor(new W3CBuilder(out));
+        traversor.traverse(rootEl);
+    }
+
+    /** Implements the conversion by walking the input. */
+    protected static class W3CBuilder implements NodeVisitor {
+        private static final String xmlnsKey = "xmlns";
+        private static final String xmlnsPrefix = "xmlns:";
+
+        private final Document doc;
+        private final HashMap<String, String> namespaces = new HashMap<String, String>(); // prefix => urn
+        private Element dest;
+
+        public W3CBuilder(Document doc) {
+            this.doc = doc;
+        }
+
+        @Override
+        public void head(org.jsoup.nodes.Node source, int depth) {
+            if (source instanceof org.jsoup.nodes.Element) {
+                org.jsoup.nodes.Element sourceEl = (org.jsoup.nodes.Element) source;
+
+                String prefix = updateNamespaces(sourceEl);
+                String namespace = namespaces.get(prefix);
+
+                Element el = doc.createElementNS(namespace, sourceEl.tagName());
+                copyAttributes(sourceEl, el);
+                if (dest == null) { // sets up the root
+                    doc.appendChild(el);
+                }
+                else {
+                    dest.appendChild(el);
+                }
+                dest = el; // descend
+            }
+            else if (source instanceof org.jsoup.nodes.TextNode) {
+                org.jsoup.nodes.TextNode sourceText = (org.jsoup.nodes.TextNode) source;
+                Text text = doc.createTextNode(sourceText.getWholeText());
+                dest.appendChild(text);
+            }
+            else if (source instanceof org.jsoup.nodes.Comment) {
+                org.jsoup.nodes.Comment sourceComment = (org.jsoup.nodes.Comment) source;
+                Comment comment = doc.createComment(sourceComment.getData());
+                dest.appendChild(comment);
+            }
+            else if (source instanceof org.jsoup.nodes.DataNode) {
+                org.jsoup.nodes.DataNode sourceData = (org.jsoup.nodes.DataNode) source;
+                Text node = doc.createTextNode(sourceData.getWholeData());
+                dest.appendChild(node);
+            }
+            else {
+                // unhandled
+            }
+        }
+
+        @Override
+        public void tail(org.jsoup.nodes.Node source, int depth) {
+            if (source instanceof org.jsoup.nodes.Element && dest.getParentNode() instanceof Element) {
+                dest = (Element) dest.getParentNode(); // undescend. cromulent.
+            }
+        }
+
+        private void copyAttributes(org.jsoup.nodes.Node source, Element el) {
+            for (Attribute attribute : source.attributes()) {
+                // catch invalid characters in attribute name
+                try {
+                    el.setAttribute(attribute.getKey(), attribute.getValue());
+                }
+                catch (DOMException e) {
+                    if (e.getMessage().startsWith("INVALID_CHARACTER_ERR")) {
+                        // ignore the invalid attribute completely
+                        continue;
+                    }
+                    throw e;
+                }
+            }
+        }
+
+        /** Finds any namespaces defined in this element. Returns any tag prefix. */
+        private String updateNamespaces(org.jsoup.nodes.Element el) {
+            // scan the element for namespace declarations
+            // like: xmlns="blah" or xmlns:prefix="blah"
+            Attributes attributes = el.attributes();
+            for (Attribute attr : attributes) {
+                String key = attr.getKey();
+                String prefix;
+                if (key.equals(xmlnsKey)) {
+                    prefix = "";
+                }
+                else if (key.startsWith(xmlnsPrefix)) {
+                    prefix = key.substring(xmlnsPrefix.length());
+                }
+                else {
+                    continue;
+                }
+                namespaces.put(prefix, attr.getValue());
+            }
+
+            // get the element prefix if any
+            int pos = el.tagName().indexOf(":");
+            return pos > 0 ? el.tagName().substring(0, pos) : "";
+        }
+
+    }
+
+    /** Serialize a W3C document to a String.
+     * @param doc Document
+     * @return Document as string */
+    public String asString(Document doc) {
+        try {
+            DOMSource domSource = new DOMSource(doc);
+            StringWriter writer = new StringWriter();
+            StreamResult result = new StreamResult(writer);
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer transformer = tf.newTransformer();
+            transformer.transform(domSource, result);
+            return writer.toString();
+        }
+        catch (TransformerException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
This is achieved by copying the Jsoup class W3CDom and adjusting
its internal method copyAttributes.