### PR TITLE
Define httpclient version in own POM due to direct code dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,13 @@
 			<artifactId>jsoup</artifactId>
 			<version>1.9.1</version>
 		</dependency>
+		
+		<!-- for REST communication with ACM server -->
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.1</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Also, the line break format has changed from WIN to UNIX.