### PR TITLE
Add ChromeOptions -disable-extensions

### DIFF
--- a/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Driver.java
+++ b/src/main/java/org/aludratest/service/gui/web/selenium/selenium2/Selenium2Driver.java
@@ -196,6 +196,7 @@ final class Selenium2Driver {
         DesiredCapabilities caps = DesiredCapabilities.chrome();
         ChromeOptions opts = new ChromeOptions();
         opts.addArguments("--disable-extensions");
+        opts.addArguments("-disable-extensions");
         caps.setCapability(ChromeOptions.CAPABILITY, opts);
         return caps;
     }


### PR DESCRIPTION
Chromedriver v2.28 is ignoring the disable-extensions argument with double dash, thus added single dash argument. Previous line 198 has been kept for backward compatibility.